### PR TITLE
issue #118 TextArea: added methods is() and assertThat() to docs

### DIFF
--- a/source/includes/_documentation.md
+++ b/source/includes/_documentation.md
@@ -938,6 +938,8 @@ Here is a list of available methods in C#:
 **minlength()** | returns value of minlength attribute | int
 **maxlength()** | returns value of maxlength attribute | int
 **placeholder()** | returns value of placeholder attribute | String
+**is()** | returns object for work with assertions  | TextAreaAssert
+**assertThat()** | returns object for work with assertions  | TextAreaAssert
 
   [Test examples in Java](https://github.com/jdi-testing/jdi-light/blob/master/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/simple/TextAreaTests.java)
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->