### PR TITLE
Change the order of the blocks in the documentation

### DIFF
--- a/source/includes/documentation/_vue_js_elements.md
+++ b/source/includes/documentation/_vue_js_elements.md
@@ -20,7 +20,6 @@
 For examples of usage see: [Custom vuetify alert example](https://github.com/jdi-testing/jdi-light/blob/3118-implement-alerts/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/CustomAlert.java)
 and [JDI vuetify page tests for alerts](https://github.com/jdi-testing/jdi-light/blob/3118-implement-alerts/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/common/AlertsTests.java).
 
-
 ### Avatars
 
 [Vuetify documentation page](https://vuetifyjs.com/en/components/avatars/)
@@ -46,7 +45,6 @@ and [JDI vuetify page tests for alerts](https://github.com/jdi-testing/jdi-light
 
 For examples of usage see: [Custom vuetify avatar example (profile card)](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/ProfileCard.java)
 and [JDI vuetify page tests for avatars](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/common/AvatarsTests.java).
-
 
 ### Banners
 
@@ -77,43 +75,93 @@ Basically, you have methods that can return you elements containing in banner (b
 
 For examples of usage see: [JDI vuetify page tests for banners](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/BannersTests.java).
 
+### Bars
 
-### Bottom sheets
+### App Bars
 
-[Vuetify documentation page](https://vuetifyjs.com/en/components/bottom-sheets/)
+[Vuetify documentation page](https://vuetifyjs.com/en/components/app-bars/)
 
-- __Java__: _com.epam.jdi.light.vuetify.elements.composite.BottomSheet.java_
-
-```java
-public class TextBottomSheet extends BottomSheet {
-  @UI(".text-center > div")
-  protected Text text;
-  @UI("button")
-  protected Button button;
-  public void close() { button.click(); }
-  public Text sheetText() { return text; }
-}
-```
-
-Bottom sheet is a form of dialog that appears at the bottom of a page.
-You can inherit the class and define the inner content of the sheet. 
-
+- __Java__: _com.epam.jdi.light.vuetify.elements.complex.bars.AppBar.java_
 
 ```java
-@Test
-public void checkInsetSheetCssProps() {
-    insetBottomSheet.is().hidden();
-    insetBottomSheetButton.click();
-    insetBottomSheet.is().displayed();
-    insetBottomSheet.sheetText().has().text(containsString("the inset prop"));
-    insetBottomSheet.close();
-    insetBottomSheet.is().hidden();
-}
+    @Test
+    public void collapsibleBarTests() {
+        collapsibleBar.is().displayed();
+        collapsibleBar.has().menuButton();
+        collapsibleBar.has().title();
+        collapsibleBar.has().properTitleText("Collapsing Bar");
+        collapsibleBar.scrollBarToBottom();
+        collapsibleBar.has().hiddenTitle();
+        collapsibleBar.scrollBarToTop();
+        collapsibleBar.has().title();
+        collapsibleBar.has().checker();
+        collapsibleBar.is().checkerChecked();
+        collapsibleBar.getChecker().click();
+        collapsibleBar.is().checkerUnchecked();
+        collapsibleBar.has().hiddenTitle();
+        collapsibleBar.getChecker().click();
+        collapsibleBar.has().title();
+    }
 ```
 
-![Bottom sheet example](../../images/vuetify/bottom-sheet.png)
+![App bars example](../../images/vuetify/app-bars.png)
 
-For examples of usage see: [Vuetify Bottom sheets tests](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/composite/BottomSheetsTests.java).
+The app bar component is pivotal to any graphical user interface (GUI), as it generally is the primary source of site navigation.
+
+
+For examples of usage see: [JDI vuetify page tests for app bars](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/AppBarsTests.java).
+
+### Toolbars
+
+[Vuetify documentation page](https://vuetifyjs.com/en/components/toolbars/)
+
+- __Java__: _com.epam.jdi.light.vuetify.elements.complex.bars.ToolBar.java_
+
+```java
+    @Test
+    public void denseToolbarTests() {
+        denseToolbar.is().displayed();
+        denseToolbar.has().menuButton();
+        denseToolbar.has().title();
+        denseToolbar.has().properTitleText("Title");
+        denseToolbar.has().searchButton();
+        denseToolbar.has().heartButton();
+        denseToolbar.has().verticalDotsButton();
+        denseToolbar.is().dense();
+        denseToolbar.has().height("48");
+    }
+```
+
+![Toolbars example](../../images/vuetify/toolbars.png)
+
+The toolbar component is pivotal to any gui, as it generally is the primary source of site navigation.
+
+For examples of usage see: [JDI vuetify page tests for toolbars](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ToolBarsTests.java).
+
+### System bars
+
+[Vuetify documentation page](https://vuetifyjs.com/en/components/system-bars/)
+
+- __Java__: _com.epam.jdi.light.vuetify.elements.complex.bars.SystemBar.java_
+
+```java
+    @Test
+    public void systemBarColoredPrimaryTests() {
+        systemBarColoredPrimary.is().displayed();
+        systemBarColoredPrimary.has().text("System bar color 1");
+        systemBarColoredPrimary.has().wiFiIcon();
+        systemBarColoredPrimary.has().signalIcon();
+        systemBarColoredPrimary.has().batteryIcon();
+        systemBarColoredPrimary.has().time("12:30");
+        systemBarColoredPrimary.has().backgroundColor(BLUE_DARKEN_2.value());
+    }
+```
+
+![System bars example](../../images/vuetify/system-bars.png)
+
+The system bar component can be used for displaying statuses to the user. It looks like the Android system bar and can contain icons, spacers, and some text.
+
+For examples of usage see: [JDI vuetify page tests for system bars](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/SystemBarsTests.java).
 
 
 ### Bottom navigation
@@ -162,98 +210,42 @@ This name contains a WebList of buttons and provides access to them by index.
 **getButtonWight()** | Return Button Wight  | String
 **getButtonText** | Return Button Text | String
 
+### Bottom sheets
 
+[Vuetify documentation page](https://vuetifyjs.com/en/components/bottom-sheets/)
 
-### Bars
-
-### App Bars
-
-[Vuetify documentation page](https://vuetifyjs.com/en/components/app-bars/)
-
-- __Java__: _com.epam.jdi.light.vuetify.elements.complex.bars.AppBar.java_
+- __Java__: _com.epam.jdi.light.vuetify.elements.composite.BottomSheet.java_
 
 ```java
-    @Test
-    public void collapsibleBarTests() {
-        collapsibleBar.is().displayed();
-        collapsibleBar.has().menuButton();
-        collapsibleBar.has().title();
-        collapsibleBar.has().properTitleText("Collapsing Bar");
-        collapsibleBar.scrollBarToBottom();
-        collapsibleBar.has().hiddenTitle();
-        collapsibleBar.scrollBarToTop();
-        collapsibleBar.has().title();
-        collapsibleBar.has().checker();
-        collapsibleBar.is().checkerChecked();
-        collapsibleBar.getChecker().click();
-        collapsibleBar.is().checkerUnchecked();
-        collapsibleBar.has().hiddenTitle();
-        collapsibleBar.getChecker().click();
-        collapsibleBar.has().title();
-    }
+public class TextBottomSheet extends BottomSheet {
+  @UI(".text-center > div")
+  protected Text text;
+  @UI("button")
+  protected Button button;
+  public void close() { button.click(); }
+  public Text sheetText() { return text; }
+}
 ```
 
-![App bars example](../../images/vuetify/app-bars.png)
+Bottom sheet is a form of dialog that appears at the bottom of a page.
+You can inherit the class and define the inner content of the sheet.
 
-The app bar component is pivotal to any graphical user interface (GUI), as it generally is the primary source of site navigation.
-
-
-For examples of usage see: [JDI vuetify page tests for app bars](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/AppBarsTests.java).
-
-
-### Toolbars
-
-[Vuetify documentation page](https://vuetifyjs.com/en/components/toolbars/)
-
-- __Java__: _com.epam.jdi.light.vuetify.elements.complex.bars.ToolBar.java_
 
 ```java
-    @Test
-    public void denseToolbarTests() {
-        denseToolbar.is().displayed();
-        denseToolbar.has().menuButton();
-        denseToolbar.has().title();
-        denseToolbar.has().properTitleText("Title");
-        denseToolbar.has().searchButton();
-        denseToolbar.has().heartButton();
-        denseToolbar.has().verticalDotsButton();
-        denseToolbar.is().dense();
-        denseToolbar.has().height("48");
-    }
+@Test
+public void checkInsetSheetCssProps() {
+    insetBottomSheet.is().hidden();
+    insetBottomSheetButton.click();
+    insetBottomSheet.is().displayed();
+    insetBottomSheet.sheetText().has().text(containsString("the inset prop"));
+    insetBottomSheet.close();
+    insetBottomSheet.is().hidden();
+}
 ```
 
-![Toolbars example](../../images/vuetify/toolbars.png)
+![Bottom sheet example](../../images/vuetify/bottom-sheet.png)
 
-The toolbar component is pivotal to any gui, as it generally is the primary source of site navigation.
-
-For examples of usage see: [JDI vuetify page tests for toolbars](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ToolBarsTests.java).
-
-
-### System bars
-
-[Vuetify documentation page](https://vuetifyjs.com/en/components/system-bars/)
-
-- __Java__: _com.epam.jdi.light.vuetify.elements.complex.bars.SystemBar.java_
-
-```java
-    @Test
-    public void systemBarColoredPrimaryTests() {
-        systemBarColoredPrimary.is().displayed();
-        systemBarColoredPrimary.has().text("System bar color 1");
-        systemBarColoredPrimary.has().wiFiIcon();
-        systemBarColoredPrimary.has().signalIcon();
-        systemBarColoredPrimary.has().batteryIcon();
-        systemBarColoredPrimary.has().time("12:30");
-        systemBarColoredPrimary.has().backgroundColor(BLUE_DARKEN_2.value());
-    }
-```
-
-![System bars example](../../images/vuetify/system-bars.png)
-
-The system bar component can be used for displaying statuses to the user. It looks like the Android system bar and can contain icons, spacers, and some text.
-
-For examples of usage see: [JDI vuetify page tests for system bars](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/SystemBarsTests.java).
-
+For examples of usage see: [Vuetify Bottom sheets tests](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/composite/BottomSheetsTests.java).
 
 ### Breadcrumbs
 
@@ -296,7 +288,6 @@ It is **necessary** to specify **the root** of an element
 
 
 For examples of usage see: [Vuetify Breadcrumbs tests](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/BreadcrumbsTests.java).
-
 
 ### Cards
 
@@ -346,7 +337,6 @@ card `text` element, but the `text` method is inherited from `UIBaseElement` tha
 
 For examples of usage see: [Custom vuetify card examples](https://github.com/jdi-testing/jdi-light/tree/vuetify-develop/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/cards)
 and [JDI vuetify page tests for cards](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/CardsTests.java).
-
 
 ### Expansion Panels
 
@@ -407,7 +397,6 @@ Also, you can inherit the `ExpansionPanels`.
 
 For examples of usage see: [Custom vuetify expansion panels examples](https://github.com/jdi-testing/jdi-light/tree/vuetify-develop/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/panels)
 and [JDI vuetify page tests for expansion panels](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ExpansionPanelsTest.java).
-
 
 ### Footers
 
@@ -668,6 +657,276 @@ Text fields components are used for collecting user provided information.
 For examples of usage see: [JDI Vuetify Text fields tests](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/TextFieldsTests.java).
 
 
+### Groups 
+
+### Button Groups
+
+[Vuetify documentation page](https://vuetifyjs.com/en/components/button-groups/)
+
+- __Java__: _com.epam.jdi.light.vuetify.elements.complex.ButtonGroup.java_
+
+```java
+@JDIButtonGroup(
+        root = "#RoundedButtonGroup .v-item-group", 
+        buttons = "//*[@type = 'button']"
+) // buttons search strategy is custom
+public static ButtonGroup roundedButtonGroup;
+```
+
+Button group is a complex container for buttons.
+
+When you are using the `@UI` annotation, provide
+a selector not for the list of buttons, but for the container.
+See [different examples](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/ButtonGroupsPage.java) of using `@UI` and `@JDIButtonGroup` annotations together and separately.
+
+
+```java
+@Test
+public void mandatoryButtonGroupTest() {
+    mandatoryButtonGroup.is().displayed();
+    mandatoryButtonGroup.has().css("width", "197px");
+    mandatoryButtonGroup.getButtonByIndex(1).has().css("width", "50px");
+    assertSelected(mandatoryButtonGroup.getButtonByIndex(1));
+    mandatoryButtonGroup.getButtonByIndex(2).click();
+    assertSelected(mandatoryButtonGroup.getButtonByIndex(2));
+    mandatoryButtonGroup.getAllButtons().forEach(HasClick::click);
+    assertSelected(mandatoryButtonGroup.getButtonByIndex(4));
+}
+```
+
+![Button group example](../../images/vuetify/button-group.png)
+
+
+For examples of usage see: [Vuetify Button groups tests](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ButtonGroupsTests.java).
+
+### List Item Groups
+[Vuetify documentation page](https://vuetifyjs.com/en/components/list-item-groups/)
+
+- __Java__: _com.epam.jdi.light.vuetify.elements.complex.ListItemGroups.java_
+
+__List item groups__ - a group of selectable items from any component. Items can contains an icon, text, actions etc.
+
+List are a continuous group of text or images. They are composed of items containing primary and supplemental actions, which are represented by icons and text.
+
+```java
+    @UI("#ActiveClassListItemGroup .v-list-item")
+    public static ListItemGroups activeClassListItemGroup;
+
+    @UI("#MandatoryListItemGroup .v-list-item")
+    public static ListItemGroups mandatoryListItemGroup;
+
+    @UI("#MultipleListItemGroup .v-list-item")
+    public static ListItemGroups multipleListItemGroup;
+
+    @UI("#FlatListListItemGroup .v-list-item")
+    public static ListItemGroups flatListListItemGroup;
+
+    @UI("#SelectionControlsListItemGroup .v-list-item")
+    public static ListItemGroups selectionControlsListItemGroup;
+
+    @UI("#SelectionControlsListItemGroup div[role='option']")
+    public static List<Checkbox> selectionControlsListItemGroupCheckbox;
+```
+See [different examples](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/ListItemGroupsPage.java)
+
+The v-list-item-group provides the ability to create a group of selectable v-list-items. The v-list-item-group component utilizes v-item-group at its core to provide a clean interface for interactive lists.
+
+![List item groups example](../../images/vuetify/list-item.png)
+![List item groups example](../../images/vuetify/checkbox-list-item.png)
+
+|Method | Description | Return Type
+--- | --- | ---
+**select(String value)** | Finds required element by its name and selects | void
+**select(int index)** | Finds required element by its index and selects | void
+**get(String value)** | Finds required element by its name and returns it | UIElement
+**get(int index)** | Finds required element by its index and returns it | UIElement
+**isActive(int elementIndex)** | Shows that required element is active | boolean
+**isInactivate(int elementIndex)** | Shows that required element is inactive | boolean
+**hasIcon(int elementIndex)** | Shows that required element has icon | boolean
+**hasTitle(int elementIndex, String expectedTitle)** | Shows that required element has expected title | boolean
+
+#### Active class
+
+You can set a class which will be added when an item is selected.
+
+```java
+@Test
+public static void activeClassListItemGroupTest() {
+
+  int elemIndex = 1;
+  String[] expectedTitles = {"Wifi", "Bluetooth", "Data Usage"};
+
+  for (String expectedTitle : expectedTitles) {
+    activeClassListItemGroup.select(elemIndex);
+    jdiAssert(activeClassListItemGroup.isActive(elemIndex), Matchers.is(true));
+    jdiAssert(activeClassListItemGroup.hasIcon(elemIndex), Matchers.is(true));
+    jdiAssert(activeClassListItemGroup.hasTitle(elemIndex, expectedTitle), Matchers.is(true));
+    activeClassListItemGroup.select(elemIndex);
+    jdiAssert(activeClassListItemGroup.isInactivate(elemIndex), Matchers.is(true));
+
+    elemIndex++;
+  }
+}
+```
+#### Mandatory class
+
+At least one item must be selected.
+
+```java
+@Test
+public static void mandatoryListItemGroupTest() {
+
+  for (int element = 1; element < 4; element++) {
+      mandatoryListItemGroup.select(element);
+      jdiAssert(mandatoryListItemGroup.isActive(element), Matchers.is(true));
+      mandatoryListItemGroup.select(element);
+      jdiAssert(mandatoryListItemGroup.isInactivate(element), Matchers.is(false));
+  }
+
+  for (int element = 1; element < 4; element++) {
+      mandatoryListItemGroup.select(element);
+  }
+
+  jdiAssert(mandatoryListItemGroup.isActive(3), Matchers.is(true));
+  jdiAssert(mandatoryListItemGroup.isInactivate(1), Matchers.is(true));
+  jdiAssert(mandatoryListItemGroup.isInactivate(2), Matchers.is(true));
+}
+```
+#### Multiple class
+
+You can select multiple items at one time.
+
+```java
+@Test
+public static void multipleListItemGroupsTest() {
+  for (int element = 1; element < 4; element++) {
+      if (multipleListItemGroup.isInactivate(element)) {
+          multipleListItemGroup.select(element);
+      }
+  }
+
+  for (int element = 1; element < 4; element++) {
+      jdiAssert(multipleListItemGroup.isActive(element), Matchers.is(true));
+  }
+
+  for (int element = 1; element < 4; element++) {
+      multipleListItemGroup.select(element);
+      jdiAssert(multipleListItemGroup.isInactivate(element), Matchers.is(true));
+  }
+}
+```
+
+#### Flat list
+
+You can easily disable the default highlighting of selected v-list-items. This creates a lower profile for a user’s choices.
+
+```java
+@Test
+public static void flatListListItemGroupTest() {
+
+  for (int element = 1; element < 4; element++) {
+      flatListListItemGroup.select(element);
+      jdiAssert(flatListListItemGroup.isActive(element), Matchers.is(true));
+      jdiAssert(flatListListItemGroup.hasIcon(element), Matchers.is(true));
+      flatListListItemGroup.select(element);
+      jdiAssert(flatListListItemGroup.isInactivate(element), Matchers.is(true));
+  }
+}
+```
+
+#### Selection controls
+
+Using the default slot, you can access an items internal state and toggle it. Since the active property is a boolean, we use the true-value prop on the checkbox to link its state to the v-list-item.
+
+```java
+@Test
+public static void selectionControlsListItemGroupTest() {
+  int elemIndex = 1;
+  String[] expectedTitles = {"Dog Photos", "Cat Photos", "Potatoes", "Carrots"};
+
+  for (String expectedTitle : expectedTitles) {
+
+      jdiAssert(selectionControlsListItemGroup.hasTitle(elemIndex, expectedTitle), Matchers.is(true));
+      selectionControlsListItemGroupCheckbox.get(elemIndex).check();
+      selectionControlsListItemGroupCheckbox.get(elemIndex).is().checked();
+      selectionControlsListItemGroupCheckbox.get(elemIndex).uncheck();
+      selectionControlsListItemGroupCheckbox.get(elemIndex).is().unchecked();
+
+      elemIndex++;
+  }
+
+  for (int element = 1; element < 5; element++) {
+      selectionControlsListItemGroupCheckbox.get(element).check();
+  }
+  for (int element = 1; element < 5; element++) {
+      selectionControlsListItemGroupCheckbox.get(element).is().checked();
+  }
+}
+```
+
+For examples of usage see: [Vuetify List Item Groups tests](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ListItemGroupsTests.java).
+
+### Windows
+
+[Vuetify documentation page](https://vuetifyjs.com/en/components/windows/)
+
+- __Java__: _com.epam.jdi.light.vuetify.elements.complex.Windows.java_
+
+```java
+    @UI("#ReverseWindow .v-window")
+    public static Windows<SlideWindow> reverseWindows;
+
+    @UI("#AccountCreationWindow .v-window")
+    public static Windows<?> accountCreationWindows;
+```
+
+![Windows example](../../images/vuetify/windows.png)
+
+The v-window component provides the baseline functionality for
+transitioning content from 1 pane to another.
+
+Windows component is a container. So, you should use
+it with another class for contained element.
+**That class must implement `ICoreElement` interface**.
+For example: UIElement, Section or your custom class.
+
+There are two ways to use windows class:
+
+- With definite `T` type in diamond operator(<T\>)
+- With unknown type(<?>)
+
+**You should always use Windows component with diamond operator.**
+
+```java
+    @Test
+    public void reverseWindowsTest() {
+        int i = 1;
+        for (UIElement nav : reverseNavigation) {
+            nav.click();
+            reverseWindows.getActive().header().has().text("Slide " + i);
+            reverseWindows.getActive().header().has().css("color", WHITE.value());
+            reverseWindows.getActive().sheet().has().css("background-color", GREY.value());
+            i++;
+        }
+        reverseNext.click();
+        reverseWindows.getActive().header().has().text("Slide 1");
+        reverseBack.click();
+        reverseWindows.getActive().header().has().text("Slide 3");
+    }
+```
+
+|Method | Description | Return Type
+--- | --- | ---
+**getActive()** | Returns instance of `T` class from the diamond operator | T
+**getActive(Class\<U\> clazz)** | Returns instance of `U` class  | U
+
+**T and U should implement ICoreElement
+or extend a class that already implemented it.**
+
+For examples of usage see: [Custom vuetify windows examples](https://github.com/jdi-testing/jdi-light/tree/vuetify-develop/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/windows)
+and [JDI vuetify page tests for windows](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/WindowsTests.java).
+
+
 ### Lists
 
 [Vuetify documentation page](https://vuetifyjs.com/en/components/lists/)
@@ -821,243 +1080,40 @@ It is **necessary** to specify **the root** of an element.
 
 For examples of usage see: [JDI vuetify page tests for pagination](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/PaginationTests.java).
 
+### Snackbars
 
-### Button Groups
+[Vuetify documentation page](https://vuetifyjs.com/en/components/snackbars/)
 
-[Vuetify documentation page](https://vuetifyjs.com/en/components/button-groups/)
-
-- __Java__: _com.epam.jdi.light.vuetify.elements.complex.ButtonGroup.java_
-
-```java
-@JDIButtonGroup(
-        root = "#RoundedButtonGroup .v-item-group", 
-        buttons = "//*[@type = 'button']"
-) // buttons search strategy is custom
-public static ButtonGroup roundedButtonGroup;
-```
-
-Button group is a complex container for buttons. 
-
-When you are using the `@UI` annotation, provide
-a selector not for the list of buttons, but for the container.
-See [different examples](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/ButtonGroupsPage.java) of using `@UI` and `@JDIButtonGroup` annotations together and separately.
-
-
-```java
-@Test
-public void mandatoryButtonGroupTest() {
-    mandatoryButtonGroup.is().displayed();
-    mandatoryButtonGroup.has().css("width", "197px");
-    mandatoryButtonGroup.getButtonByIndex(1).has().css("width", "50px");
-    assertSelected(mandatoryButtonGroup.getButtonByIndex(1));
-    mandatoryButtonGroup.getButtonByIndex(2).click();
-    assertSelected(mandatoryButtonGroup.getButtonByIndex(2));
-    mandatoryButtonGroup.getAllButtons().forEach(HasClick::click);
-    assertSelected(mandatoryButtonGroup.getButtonByIndex(4));
-}
-```
-
-![Button group example](../../images/vuetify/button-group.png)
-
-
-For examples of usage see: [Vuetify Button groups tests](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ButtonGroupsTests.java).
-
-### List Item Groups
-[Vuetify documentation page](https://vuetifyjs.com/en/components/list-item-groups/)
-
-- __Java__: _com.epam.jdi.light.vuetify.elements.complex.ListItemGroups.java_
-
-__List item groups__ - a group of selectable items from any component. Items can contains an icon, text, actions etc.
-
-List are a continuous group of text or images. They are composed of items containing primary and supplemental actions, which are represented by icons and text.
-
-```java
-    @UI("#ActiveClassListItemGroup .v-list-item")
-    public static ListItemGroups activeClassListItemGroup;
-
-    @UI("#MandatoryListItemGroup .v-list-item")
-    public static ListItemGroups mandatoryListItemGroup;
-
-    @UI("#MultipleListItemGroup .v-list-item")
-    public static ListItemGroups multipleListItemGroup;
-
-    @UI("#FlatListListItemGroup .v-list-item")
-    public static ListItemGroups flatListListItemGroup;
-
-    @UI("#SelectionControlsListItemGroup .v-list-item")
-    public static ListItemGroups selectionControlsListItemGroup;
-
-    @UI("#SelectionControlsListItemGroup div[role='option']")
-    public static List<Checkbox> selectionControlsListItemGroupCheckbox;
-```
-See [different examples](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/ListItemGroupsPage.java)
-
-The v-list-item-group provides the ability to create a group of selectable v-list-items. The v-list-item-group component utilizes v-item-group at its core to provide a clean interface for interactive lists.
-
-![List item groups example](../../images/vuetify/list-item.png)
-![List item groups example](../../images/vuetify/checkbox-list-item.png)
-
-|Method | Description | Return Type
---- | --- | ---
-**select(String value)** | Finds required element by its name and selects | void
-**select(int index)** | Finds required element by its index and selects | void
-**get(String value)** | Finds required element by its name and returns it | UIElement
-**get(int index)** | Finds required element by its index and returns it | UIElement
-**isActive(int elementIndex)** | Shows that required element is active | boolean
-**isInactivate(int elementIndex)** | Shows that required element is inactive | boolean
-**hasIcon(int elementIndex)** | Shows that required element has icon | boolean
-**hasTitle(int elementIndex, String expectedTitle)** | Shows that required element has expected title | boolean
-
-#### Active class
-
-You can set a class which will be added when an item is selected.
-
-```java
-@Test
-public static void activeClassListItemGroupTest() {
-
-  int elemIndex = 1;
-  String[] expectedTitles = {"Wifi", "Bluetooth", "Data Usage"};
-
-  for (String expectedTitle : expectedTitles) {
-    activeClassListItemGroup.select(elemIndex);
-    jdiAssert(activeClassListItemGroup.isActive(elemIndex), Matchers.is(true));
-    jdiAssert(activeClassListItemGroup.hasIcon(elemIndex), Matchers.is(true));
-    jdiAssert(activeClassListItemGroup.hasTitle(elemIndex, expectedTitle), Matchers.is(true));
-    activeClassListItemGroup.select(elemIndex);
-    jdiAssert(activeClassListItemGroup.isInactivate(elemIndex), Matchers.is(true));
-
-    elemIndex++;
-  }
-}
-```
-#### Mandatory class
-
-At least one item must be selected.
-
-```java
-@Test
-public static void mandatoryListItemGroupTest() {
-
-  for (int element = 1; element < 4; element++) {
-      mandatoryListItemGroup.select(element);
-      jdiAssert(mandatoryListItemGroup.isActive(element), Matchers.is(true));
-      mandatoryListItemGroup.select(element);
-      jdiAssert(mandatoryListItemGroup.isInactivate(element), Matchers.is(false));
-  }
-
-  for (int element = 1; element < 4; element++) {
-      mandatoryListItemGroup.select(element);
-  }
-
-  jdiAssert(mandatoryListItemGroup.isActive(3), Matchers.is(true));
-  jdiAssert(mandatoryListItemGroup.isInactivate(1), Matchers.is(true));
-  jdiAssert(mandatoryListItemGroup.isInactivate(2), Matchers.is(true));
-}
-```
-#### Multiple class
-
-You can select multiple items at one time.
-
-```java
-@Test
-public static void multipleListItemGroupsTest() {
-  for (int element = 1; element < 4; element++) {
-      if (multipleListItemGroup.isInactivate(element)) {
-          multipleListItemGroup.select(element);
-      }
-  }
-
-  for (int element = 1; element < 4; element++) {
-      jdiAssert(multipleListItemGroup.isActive(element), Matchers.is(true));
-  }
-
-  for (int element = 1; element < 4; element++) {
-      multipleListItemGroup.select(element);
-      jdiAssert(multipleListItemGroup.isInactivate(element), Matchers.is(true));
-  }
-}
-```
-
-#### Flat list 
-
-You can easily disable the default highlighting of selected v-list-items. This creates a lower profile for a user’s choices.
-
-```java
-@Test
-public static void flatListListItemGroupTest() {
-
-  for (int element = 1; element < 4; element++) {
-      flatListListItemGroup.select(element);
-      jdiAssert(flatListListItemGroup.isActive(element), Matchers.is(true));
-      jdiAssert(flatListListItemGroup.hasIcon(element), Matchers.is(true));
-      flatListListItemGroup.select(element);
-      jdiAssert(flatListListItemGroup.isInactivate(element), Matchers.is(true));
-  }
-}
-```
-
-#### Selection controls
-
-Using the default slot, you can access an items internal state and toggle it. Since the active property is a boolean, we use the true-value prop on the checkbox to link its state to the v-list-item.
-
-```java
-@Test
-public static void selectionControlsListItemGroupTest() {
-  int elemIndex = 1;
-  String[] expectedTitles = {"Dog Photos", "Cat Photos", "Potatoes", "Carrots"};
-
-  for (String expectedTitle : expectedTitles) {
-
-      jdiAssert(selectionControlsListItemGroup.hasTitle(elemIndex, expectedTitle), Matchers.is(true));
-      selectionControlsListItemGroupCheckbox.get(elemIndex).check();
-      selectionControlsListItemGroupCheckbox.get(elemIndex).is().checked();
-      selectionControlsListItemGroupCheckbox.get(elemIndex).uncheck();
-      selectionControlsListItemGroupCheckbox.get(elemIndex).is().unchecked();
-
-      elemIndex++;
-  }
-
-  for (int element = 1; element < 5; element++) {
-      selectionControlsListItemGroupCheckbox.get(element).check();
-  }
-  for (int element = 1; element < 5; element++) {
-      selectionControlsListItemGroupCheckbox.get(element).is().checked();
-  }
-}
-```
-
-For examples of usage see: [Vuetify List Item Groups tests](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ListItemGroupsTests.java).
-
-### Tabs
-
-[Vuetify documentation page](https://vuetifyjs.com/en/components/tabs/)
-
-- __Java__: _com.epam.jdi.light.ui.html.elements.complex.Tabs.java_
+- __Java__: _com.epam.jdi.light.vuetify.elements.common.Snackbar.java_
 
 ```java
     @Test
-    public static void iconsTextTabsTest() {
-        iconAndTextTabs.select(1);
-        iconAndTextTabs.get(1).is().text("RECENTS");
-        iconAndTextTabsIcon.get(1).is().visible();
-
-        iconAndTextTabs.select(2);
-        iconAndTextTabs.get(2).is().text("FAVORITES");
-        iconAndTextTabsIcon.get(2).is().visible();
-
-        iconAndTextTabs.select(3);
-        iconAndTextTabs.get(3).is().text("NEARBY");
-        iconAndTextTabsIcon.get(3).is().visible();
-    }
+    public static void simpleSnackbarTest() {
+        simpleSnackbarOpen.click();
+        simpleSnackbar.is().visible();
+        simpleSnackbar.is().text("Hello, I'm a snackbar");
+        simpleSnackbar.close();
+        simpleSnackbar.is().closed();
+  }
 ```
 
-![Tabs example](../../images/vuetify/tabs.png)
+![Snackbars example](../../images/vuetify/snackbars.png)
 
-Tabs - a list of tabs which may be implemented as buttons, links, icons etc. You can inherit the `Tabs` class and customize it the way you want.
+The snackbar component is used to display a quick message to a user.
 
-For examples of usage see: [JDI vuetify page tests for tabs](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/TabsTests.java).
+|Method | Description | Return Type
+--- | --- | ---
+**is()** | Returns Assert class | SnackbarAssert
+**text()** | Returns snackbar's text | String
+**close()** | Closes snackbar | void
+**isOpen()** | Shows that snackbar is open | boolean
+**isClosed()** | Shows that snackbar is closed | boolean
+**isLeft()** | Shows that snackbar has left position | boolean
+**isRight()** | Shows that snackbar has right position | boolean
+**isCentered()** | Shows that snackbar is centered | boolean
+**isVertical()** | Shows that snackbar is vertical | boolean
 
+For examples of usage see: [JDI vuetify page tests for snackbars](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/common/SnackbarsTests.java).
 
 ### Subheaders
 
@@ -1116,98 +1172,34 @@ The Simple Table component is a simple wrapper component around the table elemen
 
 For examples of usage see: [Vuetify Simple Table tests](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/SimpleTablesTests.java#L40).
 
-### Windows
 
-[Vuetify documentation page](https://vuetifyjs.com/en/components/windows/)
+### Tabs
 
-- __Java__: _com.epam.jdi.light.vuetify.elements.complex.Windows.java_
+[Vuetify documentation page](https://vuetifyjs.com/en/components/tabs/)
 
-```java
-    @UI("#ReverseWindow .v-window")
-    public static Windows<SlideWindow> reverseWindows;
-
-    @UI("#AccountCreationWindow .v-window")
-    public static Windows<?> accountCreationWindows;
-```
-
-![Windows example](../../images/vuetify/windows.png)
-
-The v-window component provides the baseline functionality for 
-transitioning content from 1 pane to another.
-
-Windows component is a container. So, you should use 
-it with another class for contained element. 
-**That class must implement `ICoreElement` interface**.
-For example: UIElement, Section or your custom class.
-
-There are two ways to use windows class:
-
-- With definite `T` type in diamond operator(<T\>)
-- With unknown type(<?>)
-
-**You should always use Windows component with diamond operator.**
+- __Java__: _com.epam.jdi.light.ui.html.elements.complex.Tabs.java_
 
 ```java
     @Test
-    public void reverseWindowsTest() {
-        int i = 1;
-        for (UIElement nav : reverseNavigation) {
-            nav.click();
-            reverseWindows.getActive().header().has().text("Slide " + i);
-            reverseWindows.getActive().header().has().css("color", WHITE.value());
-            reverseWindows.getActive().sheet().has().css("background-color", GREY.value());
-            i++;
-        }
-        reverseNext.click();
-        reverseWindows.getActive().header().has().text("Slide 1");
-        reverseBack.click();
-        reverseWindows.getActive().header().has().text("Slide 3");
+    public static void iconsTextTabsTest() {
+        iconAndTextTabs.select(1);
+        iconAndTextTabs.get(1).is().text("RECENTS");
+        iconAndTextTabsIcon.get(1).is().visible();
+
+        iconAndTextTabs.select(2);
+        iconAndTextTabs.get(2).is().text("FAVORITES");
+        iconAndTextTabsIcon.get(2).is().visible();
+
+        iconAndTextTabs.select(3);
+        iconAndTextTabs.get(3).is().text("NEARBY");
+        iconAndTextTabsIcon.get(3).is().visible();
     }
 ```
 
-|Method | Description | Return Type
---- | --- | ---
-**getActive()** | Returns instance of `T` class from the diamond operator | T
-**getActive(Class\<U\> clazz)** | Returns instance of `U` class  | U
+![Tabs example](../../images/vuetify/tabs.png)
 
-**T and U should implement ICoreElement 
-or extend a class that already implemented it.**
+Tabs - a list of tabs which may be implemented as buttons, links, icons etc. You can inherit the `Tabs` class and customize it the way you want.
 
-For examples of usage see: [Custom vuetify windows examples](https://github.com/jdi-testing/jdi-light/tree/vuetify-develop/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/windows) 
-and [JDI vuetify page tests for windows](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/WindowsTests.java).
+For examples of usage see: [JDI vuetify page tests for tabs](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/TabsTests.java).
 
-### Snackbars
-
-[Vuetify documentation page](https://vuetifyjs.com/en/components/snackbars/)
-
-- __Java__: _com.epam.jdi.light.vuetify.elements.common.Snackbar.java_
-
-```java
-    @Test
-    public static void simpleSnackbarTest() {
-        simpleSnackbarOpen.click();
-        simpleSnackbar.is().visible();
-        simpleSnackbar.is().text("Hello, I'm a snackbar");
-        simpleSnackbar.close();
-        simpleSnackbar.is().closed();
-  }
-```
-
-![Snackbars example](../../images/vuetify/snackbars.png)
-
-The snackbar component is used to display a quick message to a user.
-
-|Method | Description | Return Type
---- | --- | ---
-**is()** | Returns Assert class | SnackbarAssert
-**text()** | Returns snackbar's text | String
-**close()** | Closes snackbar | void
-**isOpen()** | Shows that snackbar is open | boolean
-**isClosed()** | Shows that snackbar is closed | boolean
-**isLeft()** | Shows that snackbar has left position | boolean
-**isRight()** | Shows that snackbar has right position | boolean
-**isCentered()** | Shows that snackbar is centered | boolean
-**isVertical()** | Shows that snackbar is vertical | boolean
-
-For examples of usage see: [JDI vuetify page tests for snackbars](https://github.com/jdi-testing/jdi-light/blob/vuetify-develop/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/common/SnackbarsTests.java).
 


### PR DESCRIPTION
Change the order of the blocks in the documentation to look like on https://jdi-testing.github.io/jdi-light/vuetify.
