### PR TITLE
added empty line for banners code example

### DIFF
--- a/source/includes/documentation/_vue_js_elements.md
+++ b/source/includes/documentation/_vue_js_elements.md
@@ -157,6 +157,7 @@ public void bannerTest() {
 ![Banners example](../../images/vuetify/banners.png)
 
 __Vuetify v2.6.14__ code example:
+
 ```html
 <div class="v-banner v-sheet theme--light v-banner--single-line">
     <div class="v-banner__wrapper">


### PR DESCRIPTION
Banner code example looks broken in the doc 
![image](https://user-images.githubusercontent.com/61293618/222684156-fe750dd5-7fe0-403b-be82-29b680c8016e.png)
